### PR TITLE
workflow: give input data files unique names

### DIFF
--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -1,8 +1,8 @@
 '''
 This part of the workflow expects input files
 
-        sequences = "data/sequences.fasta",
-        metadata =  "data/metadata.tsv",
+        sequences = "data/{build_name}_sequences.fasta",
+        metadata =  "data/{build_name}_metadata.tsv",
 
 and will produce output files as
 
@@ -14,9 +14,9 @@ In addition, `build_dir` and `auspice_dir` need to be defined upstream.
 
 rule wrangle_metadata:
     input:
-        metadata =  "data/metadata.tsv"
+        metadata =  "data/{build_name}_metadata.tsv"
     output:
-        metadata = "results/metadata.tsv"
+        metadata = "results/{build_name}_metadata.tsv"
     params:
         strain_id = lambda w: config.get('strain_id_field', 'strain')
     shell:
@@ -36,8 +36,8 @@ rule filter:
           - minimum genome length of {params.min_length}
         """
     input:
-        sequences = "data/sequences.fasta",
-        metadata =  "results/metadata.tsv",
+        sequences = "data/{build_name}_sequences.fasta",
+        metadata =  "results/{build_name}_metadata.tsv",
         exclude = config["exclude"]
     output:
         sequences = build_dir + "/{build_name}/filtered.fasta",

--- a/workflow/snakemake_rules/download_via_lapis.smk
+++ b/workflow/snakemake_rules/download_via_lapis.smk
@@ -1,6 +1,6 @@
 rule download_sequences_via_lapis:
     output:
-        sequences = "data/sequences.fasta",
+        sequences = "data/{build_name}_sequences.fasta",
     shell:
         """
         curl https://mpox-lapis.genspectrum.org/v1/sample/fasta --output {output.sequences}
@@ -8,7 +8,7 @@ rule download_sequences_via_lapis:
 
 rule download_metadata_via_lapis:
     output:
-        metadata = "data/metadata.tsv"
+        metadata = "data/{build_name}_metadata.tsv"
     shell:
         """
         curl https://mpox-lapis.genspectrum.org/v1/sample/details?dataFormat=csv | \

--- a/workflow/snakemake_rules/prepare.smk
+++ b/workflow/snakemake_rules/prepare.smk
@@ -1,8 +1,8 @@
 rule download:
     message: "Downloading sequences and metadata from data.nextstrain.org"
     output:
-        sequences = "data/sequences.fasta.xz",
-        metadata = "data/metadata.tsv.gz"
+        sequences = "data/{build_name}_sequences.fasta.xz",
+        metadata = "data/{build_name}_metadata.tsv.gz"
     params:
         sequences_url = "https://data.nextstrain.org/files/workflows/monkeypox/sequences.fasta.xz",
         metadata_url = "https://data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz"
@@ -15,11 +15,11 @@ rule download:
 rule decompress:
     message: "Decompressing sequences and metadata"
     input:
-        sequences = "data/sequences.fasta.xz",
-        metadata = "data/metadata.tsv.gz"
+        sequences = "data/{build_name}_sequences.fasta.xz",
+        metadata = "data/{build_name}_metadata.tsv.gz"
     output:
-        sequences = "data/sequences.fasta",
-        metadata = "data/metadata.tsv"
+        sequences = "data/{build_name}_sequences.fasta",
+        metadata = "data/{build_name}_metadata.tsv"
     shell:
         """
         gzip --decompress --keep {input.metadata}


### PR DESCRIPTION
### Description of proposed changes
I'm running into a problem when running multiple config files on different input data (ex. hmpxv1 vs. mpxv, or Nextstrain vs. LAPIS). Since the input data is hard-coded to `data/sequences.fasta` and `data/metadata.tsv` it makes it difficult to run different inputs without conflict.

One option could be to add the {build_name} into input filenames to make them unique. This is an example of the changes I've made:

```python
rule download:
    message: "Downloading sequences and metadata from data.nextstrain.org"
    output:
        sequences = "data/{build_name}_sequences.fasta.xz",
        metadata = "data/{build_name}_metadata.tsv.gz"
	...
```

### Testing

Running the following commands will produce distinct outputs in `data` and `results`:

```bash
snakemake -c 1 results/mpxv/filtered.fasta --configfile config/config_mpxv.yaml
snakemake -c 1 results/hmpxv1/filtered.fasta --configfile config/config_hmpxv1.yaml
```

- data:
	- hmpxv1_metadata.tsv
	- hmpxv1_metadata.tsv.gz
	- hmpxv1_sequences.fasta
	- hmpxv1_sequences.fasta.xz
	- mpxv_metadata.tsv
	- mpxv_metadata.tsv.gz
	- mpxv_sequences.fasta
	- mpxv_sequences.fasta.xz
- results:
	- hmpxv1/
	- hmpxv1_metadata.tsv
	- mpxv/
	- mpxv_metadata.tsv

To compare different data sources, I add the data source into the build name. For example

```yaml
#config_hmpxv1_nextstrain.yaml
build_name: "hmpxv1_nextstrain"
auspice_name: "monkeypox_hmpxv1_nextstrain"
```

```yaml
#config_hmpxv1_lapis.yaml
build_name: "hmpxv1_lapis"
auspice_name: "monkeypox_hmpxv1_lapis"
```

I quite like this approach, since it mirrors the output structure of https://github.com/nextstrain/ncov. But I would love to know more about how you're implementing multiple "builds", without invoking the full input/build logic from the ncov pipeline. Thanks!
