### PR TITLE
Move the NCBI field map to config

### DIFF
--- a/ingest/config/config.yaml
+++ b/ingest/config/config.yaml
@@ -2,6 +2,8 @@
 sources: ['genbank']
 # Pathogen NCBI Taxonomy ID
 ncbi_taxon_id: '10244'
+# Renames the NCBI dataset headers
+ncbi_field_map: 'source-data/ncbi-dataset-field-map.tsv'
 
 # Params for the transform rule
 transform:

--- a/ingest/workflow/snakemake_rules/fetch_sequences.smk
+++ b/ingest/workflow/snakemake_rules/fetch_sequences.smk
@@ -80,7 +80,7 @@ rule format_ncbi_dataset_report:
     # The only fields we do not have equivalents for are "title" and "publications"
     input:
         dataset_package="data/ncbi_dataset.zip",
-        ncbi_field_map="source-data/ncbi-dataset-field-map.tsv",
+        ncbi_field_map=config["ncbi_field_map"],
     output:
         ncbi_dataset_tsv=temp("data/ncbi_dataset_report.tsv"),
     params:


### PR DESCRIPTION


## Description of proposed changes

To be consistent with the handling of `nextclade-field-map.tsv`, move `ncbi-field-map.tsv` to config. 
This change is motivated by the following comment:

* https://github.com/nextstrain/dengue/pull/13#discussion_r1373370410

## Related issue(s)

* https://github.com/nextstrain/dengue/pull/13#discussion_r1373370410

## Checklist

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
