### PR TITLE
Rename instances of "monkeypox" to "mpox"

### DIFF
--- a/.github/workflows/fetch-and-ingest-branch.yaml
+++ b/.github/workflows/fetch-and-ingest-branch.yaml
@@ -17,7 +17,7 @@ jobs:
         run: |
           # Create JSON string for the nested upload config
           GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
-          S3_DST="s3://nextstrain-data/files/workflows/monkeypox/branch/${GITHUB_BRANCH}"
+          S3_DST="s3://nextstrain-data/files/workflows/mpox/branch/${GITHUB_BRANCH}"
           UPLOAD_CONFIG=$(jq -cn --arg S3_DST "$S3_DST" '{"s3": {"dst": $S3_DST }}')
 
           echo "upload_config=$UPLOAD_CONFIG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/rebuild-all.yaml
+++ b/.github/workflows/rebuild-all.yaml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Repository Dispatch
-        run: ./ingest/vendored/trigger nextstrain/monkeypox rebuild
+        run: ./ingest/vendored/trigger nextstrain/mpox rebuild
         env:
           PAT_GITHUB_DISPATCH: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}

--- a/.github/workflows/rebuild-hmpxv1-big.yaml
+++ b/.github/workflows/rebuild-hmpxv1-big.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       trial_name:
-        description: "If set, result will be at nextstrain.org/staging/trial/trial_name/monkeypox/mpxv"
+        description: "If set, result will be at nextstrain.org/staging/trial/trial_name/mpox/mpxv"
         required: false
       image:
         description: 'Specific container image to use for build (will override the default of "nextstrain build")'

--- a/.github/workflows/rebuild-hmpxv1.yaml
+++ b/.github/workflows/rebuild-hmpxv1.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       trial_name:
-        description: "If set, result will be at nextstrain.org/staging/trial/trial_name/monkeypox/mpxv"
+        description: "If set, result will be at nextstrain.org/staging/trial/trial_name/mpox/mpxv"
         required: false
       image:
         description: 'Specific container image to use for build (will override the default of "nextstrain build")'

--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       trial_name:
-        description: "If set, result will be at nextstrain.org/staging/trial/trial_name/monkeypox/mpxv"
+        description: "If set, result will be at nextstrain.org/staging/trial/trial_name/mpox/mpxv"
         required: false
       image:
         description: 'Specific container image to use for build (will override the default of "nextstrain build")'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nextstrain repository for mpox virus
 
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/nextstrain/monkeypox/master.svg)](https://results.pre-commit.ci/latest/github/nextstrain/monkeypox/master)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/nextstrain/mpox/master.svg)](https://results.pre-commit.ci/latest/github/nextstrain/mpox/master)
 
 This repository contains two workflows for the analysis of mpox virus (MPXV) data:
 

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -1,4 +1,4 @@
-# nextstrain.org/monkeypox/ingest
+# nextstrain.org/mpox/ingest
 
 This is the ingest pipeline for mpox virus sequences.
 
@@ -9,7 +9,7 @@ Follow the [standard installation instructions](https://docs.nextstrain.org/en/l
 ## Usage
 
 > NOTE: All command examples assume you are within the `ingest` directory.
-> If running commands from the outer `monkeypox` directory, please replace the `.` with `ingest`
+> If running commands from the outer `mpox` directory, please replace the `.` with `ingest`
 
 Fetch sequences with
 

--- a/ingest/config/optional.yaml
+++ b/ingest/config/optional.yaml
@@ -4,7 +4,7 @@ upload:
   # Upload params for AWS S3
   s3:
     # AWS S3 Bucket with prefix
-    dst: 's3://nextstrain-data/files/workflows/monkeypox'
+    dst: 's3://nextstrain-data/files/workflows/mpox'
     # Files to upload to S3 that are in the `data` directory
     files_to_upload: [
       'genbank.ndjson',

--- a/ingest/vendored/.gitrepo
+++ b/ingest/vendored/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/nextstrain/ingest
 	branch = main
-	commit = c02fa8120edc3a831d5c9ab16a119f1866c300e3
-	parent = bd3bd3d87b0e6f5fcfc69754cda091e33929f6e1
+	commit = a0faef53a0c6e7cc4057209454ef0852875dc3a9
+	parent = e7411323d0242b69d15b3a93185a6b683a388c28
 	method = merge
 	cmdver = 0.4.6

--- a/ingest/vendored/README.md
+++ b/ingest/vendored/README.md
@@ -12,6 +12,9 @@ Some tools may only live here temporarily before finding a permanent home in
 Nextstrain maintained pathogen repos will use [`git subrepo`](https://github.com/ingydotnet/git-subrepo) to vendor ingest scripts.
 (See discussion on this decision in https://github.com/nextstrain/ingest/issues/3)
 
+For a list of Nextstrain repos that are currently using this method, use [this
+GitHub code search](https://github.com/search?type=code&q=org%3Anextstrain+subrepo+%22remote+%3D+https%3A%2F%2Fgithub.com%2Fnextstrain%2Fingest%22).
+
 If you don't already have `git subrepo` installed, follow the [git subrepo installation instructions](https://github.com/ingydotnet/git-subrepo#installation).
 Then add the latest ingest scripts to the pathogen repo by running:
 
@@ -23,6 +26,13 @@ Any future updates of ingest scripts can be pulled in with:
 
 ```
 git subrepo pull ingest/vendored
+```
+
+If you run into merge conflicts and would like to pull in a fresh copy of the
+latest ingest scripts, pull with the `--force` flag:
+
+```
+git subrepo pull ingest/vendored --force
 ```
 
 > **Warning**
@@ -47,14 +57,14 @@ commit hash if needed.
 
 Much of this tooling originated in
 [ncov-ingest](https://github.com/nextstrain/ncov-ingest) and was passaged thru
-[monkeypox's ingest/](https://github.com/nextstrain/monkeypox/tree/@/ingest/).
-It subsequently proliferated from [monkeypox][] to other pathogen repos
-([rsv][], [zika][], [dengue][], [hepatitisB][], [forecasts-ncov][]) primarily
-thru copying.  To [counter that
+[mpox's ingest/](https://github.com/nextstrain/mpox/tree/@/ingest/). It
+subsequently proliferated from [mpox][] to other pathogen repos ([rsv][],
+[zika][], [dengue][], [hepatitisB][], [forecasts-ncov][]) primarily thru
+copying.  To [counter that
 proliferation](https://bedfordlab.slack.com/archives/C7SDVPBLZ/p1688577879947079),
 this repo was made.
 
-[monkeypox]: https://github.com/nextstrain/monkeypox
+[mpox]: https://github.com/nextstrain/mpox
 [rsv]: https://github.com/nextstrain/rsv
 [zika]: https://github.com/nextstrain/zika/pull/24
 [dengue]: https://github.com/nextstrain/dengue/pull/10

--- a/ingest/workflow/snakemake_rules/slack_notifications.smk
+++ b/ingest/workflow/snakemake_rules/slack_notifications.smk
@@ -18,7 +18,7 @@ if not slack_envvars_defined:
     )
     sys.exit(1)
 
-S3_SRC = "s3://nextstrain-data/files/workflows/monkeypox"
+S3_SRC = "s3://nextstrain-data/files/workflows/mpox"
 
 
 rule notify_on_genbank_record_change:
@@ -48,8 +48,8 @@ rule notify_on_metadata_diff:
 
 
 onstart:
-    shell("./vendored/notify-on-job-start Ingest nextstrain/monkeypox")
+    shell("./vendored/notify-on-job-start Ingest nextstrain/mpox")
 
 
 onerror:
-    shell("./vendored/notify-on-job-fail Ingest nextstrain/monkeypox")
+    shell("./vendored/notify-on-job-fail Ingest nextstrain/mpox")

--- a/ingest/workflow/snakemake_rules/trigger_rebuild.smk
+++ b/ingest/workflow/snakemake_rules/trigger_rebuild.smk
@@ -18,5 +18,5 @@ rule trigger_build:
         touch("data/trigger/rebuild.done"),
     shell:
         """
-        ./vendored/trigger-on-new-data nextstrain/monkeypox rebuild {input.metadata_upload} {input.fasta_upload}
+        ./vendored/trigger-on-new-data nextstrain/mpox rebuild {input.metadata_upload} {input.fasta_upload}
         """

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -1,6 +1,6 @@
-# nextstrain.org/monkeypox
+# nextstrain.org/mpox
 
-This is the [Nextstrain](https://nextstrain.org) build for MPXV (mpox virus). Output from this build is visible at [nextstrain.org/monkeypox](https://nextstrain.org/monkeypox).
+This is the [Nextstrain](https://nextstrain.org) build for MPXV (mpox virus). Output from this build is visible at [nextstrain.org/mpox](https://nextstrain.org/mpox).
 The lineages within the recent mpox outbreaks in humans are defined in a separate [lineage-designation repository](https://github.com/mpxv-lineages/lineage-designation).
 
 ## Software requirements
@@ -13,8 +13,8 @@ Follow the [standard installation instructions](https://docs.nextstrain.org/en/l
 
 Input sequences and metadata can be retrieved from data.nextstrain.org
 
-* [sequences.fasta.xz](https://data.nextstrain.org/files/workflows/monkeypox/sequences.fasta.xz)
-* [metadata.tsv.gz](https://data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz)
+* [sequences.fasta.xz](https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz)
+* [metadata.tsv.gz](https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz)
 
 Note that these data are generously shared by many labs around the world.
 If you analyze and plan to publish using these data, please contact these labs first.
@@ -47,7 +47,7 @@ nextstrain build . --configfile config/hmpxv1_big/config.yaml
 
 ### Deploy
 
-⚠️ The below is outdated and needs to be adjusted for the new build names (mpxv instead of monkeypox, etc.)
+⚠️ The below is outdated and needs to be adjusted for the new build names (mpox instead of monkeypox, etc.)
 
 <details>
 
@@ -84,7 +84,7 @@ There is little redirection and each rule should be able to be reasoned with on 
 
 ## Update example data
 
-[Example data](./example_data/) is used by [CI](https://github.com/nextstrain/monkeypox/actions/workflows/ci.yaml). It can also be used as a small subset of real-world data.
+[Example data](./example_data/) is used by [CI](https://github.com/nextstrain/mpox/actions/workflows/ci.yaml). It can also be used as a small subset of real-world data.
 
 Example data should be updated every time metadata schema is changed or a new clade/lineage emerges. To update, run:
 

--- a/phylogenetic/bin/notify-on-error
+++ b/phylogenetic/bin/notify-on-error
@@ -23,7 +23,7 @@ if [[ -n "$slack_ts_file" ]]; then
 elif [[ -n "${AWS_BATCH_JOB_ID}" ]]; then
   message+="See AWS Batch job \`${AWS_BATCH_JOB_ID}\` (<https://console.aws.amazon.com/batch/v2/home?region=us-east-1#jobs/detail/${AWS_BATCH_JOB_ID}|link>) for error details."
 elif [[ -n "${GITHUB_RUN_ID}" ]]; then
-  message+="See GitHub Action <https://github.com/nextstrain/monkeypox/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true|${GITHUB_RUN_ID}> for error details."
+  message+="See GitHub Action <https://github.com/nextstrain/mpox/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true|${GITHUB_RUN_ID}> for error details."
 fi
 
 "$ingest_vendored"/notify-slack "$message" \

--- a/phylogenetic/bin/notify-on-start
+++ b/phylogenetic/bin/notify-on-start
@@ -21,12 +21,12 @@ echo "Notifying Slack about starting build."
 message="Pipeline starting for the \`$build_name\` build, which will run the phylogenetics and deploy the build."
 
 if [[ -n "${GITHUB_RUN_ID}" ]]; then
-  message+=" The job was submitted by GitHub Action <https://github.com/nextstrain/monkeypox/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true|${GITHUB_RUN_ID}>."
+  message+=" The job was submitted by GitHub Action <https://github.com/nextstrain/mpox/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true|${GITHUB_RUN_ID}>."
 fi
 
 if [[ -n "${AWS_BATCH_JOB_ID}" ]]; then
   message+=" The job was launched as AWS Batch job \`${AWS_BATCH_JOB_ID}\` (<https://console.aws.amazon.com/batch/v2/home?region=us-east-1#jobs/detail/${AWS_BATCH_JOB_ID}|link>)."
-  message+=" Follow along in your local \`monkeypox\` repo with: "'```'"nextstrain build --aws-batch --no-download --attach ${AWS_BATCH_JOB_ID} . "'```'
+  message+=" Follow along in your local \`mpox\` repo with: "'```'"nextstrain build --aws-batch --no-download --attach ${AWS_BATCH_JOB_ID} . "'```'
 fi
 
 "$ingest_vendored"/notify-slack "$message" --output="$slack_response"

--- a/phylogenetic/config/description.md
+++ b/phylogenetic/config/description.md
@@ -2,31 +2,31 @@ We gratefully acknowledge the authors, originating and submitting laboratories o
 
 We maintain three views of MPXV evolution:
 
-The first is [`mpox/mpxv-IIb-B.1`] (https://nextstrain.org/mpox/mpxv-IIb-B.1), which focuses on lineage B.1 of the global outbreak that started in 2022 and includes as many sequences as possible. Here, we conduct a molecular clock analysis in which evolutionary rate is estimated from the data (with a resulting estimate of ~6 &times; 10<sup>-5</sup> subs per site per year).
+The first is [`mpox/lineage-B.1`](https://nextstrain.org/mpox/lineage-B.1), which focuses on lineage B.1 of the global outbreak that started in 2022 and includes as many sequences as possible. Here, we conduct a molecular clock analysis in which evolutionary rate is estimated from the data (with a resulting estimate of ~6 &times; 10<sup>-5</sup> subs per site per year).
 
-The second is [`mpox/mpxv-IIb`](https://nextstrain.org/mpox/mpxv-IIb), which focuses on recent viruses transmitting from human-to-human and includes viruses belonging to clade IIb. All good quality sequences that are not lineage B.1 are included, while lineage B.1 sequences is heavily subsampled to allow non-B.1 diversity to be studied.Here, we also conduct a molecular clock analysis in which evolutionary rate is estimated from the data (with a resulting estimate of ~6 &times; 10<sup>-5</sup> subs per site per year).
+The second is [`mpox/clade-IIb`](https://nextstrain.org/mpox/clade-IIb), which focuses on recent viruses transmitting from human-to-human and includes viruses belonging to clade IIb. All good quality sequences that are not lineage B.1 are included, while lineage B.1 sequences is heavily subsampled to allow non-B.1 diversity to be studied.Here, we also conduct a molecular clock analysis in which evolutionary rate is estimated from the data (with a resulting estimate of ~6 &times; 10<sup>-5</sup> subs per site per year).
 
-The third is [`mpox/mpxv`](https://nextstrain.org/monkeypox/mpxv), which focuses on broader viral diversity and includes viruses from the animal reservoir and previous human outbreaks, encompassing clades I, IIa and IIb as described in [Happi et al](https://virological.org/t/urgent-need-for-a-non-discriminatory-and-non-stigmatizing-nomenclature-for-monkeypox-virus/853) and recently endorsed by a [WHO convened consultation](https://worldhealthorganization.cmail20.com/t/ViewEmail/d/422BD62D623B6A3D2540EF23F30FEDED/F75AF81C90108C72B4B1B1F623478121?alternativeLink=False).
+The third is [`mpox/all-clades`](https://nextstrain.org/mpox/all-clades), which focuses on broader viral diversity and includes viruses from the animal reservoir and previous human outbreaks, encompassing clades I, IIa and IIb as described in [Happi et al](https://doi.org/10.1371/journal.pbio.3001769) and endorsed by a [WHO convened consultation](https://worldhealthorganization.cmail20.com/t/ViewEmail/d/422BD62D623B6A3D2540EF23F30FEDED/F75AF81C90108C72B4B1B1F623478121?alternativeLink=False).
 
 #### Analysis
-Our bioinformatic processing workflow can be found at [github.com/nextstrain/monkeypox](https://github.com/nextstrain/monkeypox) and includes:
+Our bioinformatic processing workflow can be found at [github.com/nextstrain/mpox](https://github.com/nextstrain/mpox) and includes:
 - sequence alignment by [nextalign](https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextalign-cli.html)
 - masking several regions of the genome, including the first 1350 and last 6422 base pairs and multiple repetitive regions of variable length
 - phylogenetic reconstruction using [IQTREE-2](http://www.iqtree.org/)
 - ancestral state reconstruction and temporal inference using [TreeTime](https://github.com/neherlab/treetime)
-- clade assignment via [clade definitions defined here](https://github.com/nextstrain/monkeypox/blob/master/config/clades.tsv), to label broader MPXV clades I, IIa and IIb and to label hMPXV1 lineages A, A.1, A.1.1, etc...
+- clade assignment via [clade definitions defined here](https://github.com/nextstrain/mpox/blob/master/config/clades.tsv), to label broader MPXV clades I, IIa and IIb and to label hMPXV1 lineages A, A.1, A.1.1, etc...
 
 #### Underlying data
 We curate sequence data and metadata from the [NCBI Datasets command line tools](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/download-and-install/),
-using an NCBI Taxonomy ID defined in [ingest/config/config.yaml](https://github.com/nextstrain/monkeypox/blob/master/ingest/config/config.yaml), as starting point for these analyses.
+using an NCBI Taxonomy ID defined in [ingest/config/config.yaml](https://github.com/nextstrain/mpox/blob/master/ingest/config/config.yaml), as starting point for these analyses.
 Curated sequences and metadata are available as flat files at:
-- [data.nextstrain.org/files/workflows/monkeypox/sequences.fasta.xz](https://data.nextstrain.org/files/workflows/monkeypox/sequences.fasta.xz)
-- [data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz](https://data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz)
+- [data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz](https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz)
+- [data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz](https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz)
 
 Pairwise alignments with [Nextclade](https://clades.nextstrain.org/) against the [reference sequence MPXV-M5312_HM12_Rivers](https://www.ncbi.nlm.nih.gov/nuccore/NC_063383), insertions relative to the reference, and translated ORFs are available at
-- [data.nextstrain.org/files/workflows/monkeypox/alignment.fasta.xz](https://data.nextstrain.org/files/workflows/monkeypox/alignment.fasta.xz)
-- [data.nextstrain.org/files/workflows/monkeypox/insertions.csv.gz](https://data.nextstrain.org/files/workflows/monkeypox/insertions.csv.gz)
-- [data.nextstrain.org/files/workflows/monkeypox/translations.zip](https://data.nextstrain.org/files/workflows/monkeypox/translations.zip)
+- [data.nextstrain.org/files/workflows/mpox/alignment.fasta.xz](https://data.nextstrain.org/files/workflows/mpox/alignment.fasta.xz)
+- [data.nextstrain.org/files/workflows/mpox/insertions.csv.gz](https://data.nextstrain.org/files/workflows/mpox/insertions.csv.gz)
+- [data.nextstrain.org/files/workflows/mpox/translations.zip](https://data.nextstrain.org/files/workflows/mpox/translations.zip)
 
 #### Reusing code or images
 

--- a/phylogenetic/config/hmpxv1/auspice_config.json
+++ b/phylogenetic/config/hmpxv1/auspice_config.json
@@ -1,5 +1,5 @@
 {
-  "title": "Genomic epidemiology of MPXV",
+  "title": "Genomic epidemiology of mpox clade IIb viruses",
   "maintainers": [
     {"name": "Nextstrain team", "url": "http://nextstrain.org"}
   ],
@@ -9,7 +9,7 @@
       "url": "https://www.ncbi.nlm.nih.gov/genbank/"
     }
   ],
-  "build_url": "https://github.com/nextstrain/monkeypox",
+  "build_url": "https://github.com/nextstrain/mpox",
   "colorings": [
     {
       "key": "lineage",

--- a/phylogenetic/config/hmpxv1/config.yaml
+++ b/phylogenetic/config/hmpxv1/config.yaml
@@ -9,7 +9,7 @@ description: "config/description.md"
 tree_mask: "config/tree_mask.tsv"
 
 # Use `accession` as the ID column since `strain` currently contains duplicates¹.
-# ¹ https://github.com/nextstrain/monkeypox/issues/33
+# ¹ https://github.com/nextstrain/mpox/issues/33
 strain_id_field: "accession"
 display_strain_field: "strain"
 

--- a/phylogenetic/config/hmpxv1_big/auspice_config.json
+++ b/phylogenetic/config/hmpxv1_big/auspice_config.json
@@ -1,5 +1,5 @@
 {
-  "title": "Genomic epidemiology of hMPXV-1 (clade IIb) MPXV using as many sequences as possible",
+  "title": "Genomic epidemiology of mpox lineage B.1 viruses",
   "maintainers": [
     {"name": "Nextstrain team", "url": "http://nextstrain.org"}
   ],
@@ -9,7 +9,7 @@
       "url": "https://www.ncbi.nlm.nih.gov/genbank/"
     }
   ],
-  "build_url": "https://github.com/nextstrain/monkeypox",
+  "build_url": "https://github.com/nextstrain/mpox",
   "colorings": [
     {
       "key": "outbreak",

--- a/phylogenetic/config/hmpxv1_big/config.yaml
+++ b/phylogenetic/config/hmpxv1_big/config.yaml
@@ -9,7 +9,7 @@ description: "config/description.md"
 tree_mask: "config/tree_mask.tsv"
 
 # Use `accession` as the ID column since `strain` currently contains duplicates¹.
-# ¹ https://github.com/nextstrain/monkeypox/issues/33
+# ¹ https://github.com/nextstrain/mpox/issues/33
 strain_id_field: "accession"
 display_strain_field: "strain"
 

--- a/phylogenetic/config/mpxv/auspice_config.json
+++ b/phylogenetic/config/mpxv/auspice_config.json
@@ -1,5 +1,5 @@
 {
-  "title": "Genomic epidemiology of MPXV",
+  "title": "Genomic epidemiology of mpox viruses across clades",
   "maintainers": [
     {"name": "Nextstrain team", "url": "http://nextstrain.org"}
   ],
@@ -9,7 +9,7 @@
       "url": "https://www.ncbi.nlm.nih.gov/genbank/"
     }
   ],
-  "build_url": "https://github.com/nextstrain/monkeypox",
+  "build_url": "https://github.com/nextstrain/mpox",
   "colorings": [
     {
       "key": "outbreak",

--- a/phylogenetic/config/mpxv/config.yaml
+++ b/phylogenetic/config/mpxv/config.yaml
@@ -9,7 +9,7 @@ clades: "config/clades.tsv"
 tree_mask: "config/tree_mask.tsv"
 
 # Use `accession` as the ID column since `strain` currently contains duplicates¹.
-# ¹ https://github.com/nextstrain/monkeypox/issues/33
+# ¹ https://github.com/nextstrain/mpox/issues/33
 strain_id_field: "accession"
 display_strain_field: "strain"
 

--- a/phylogenetic/workflow/snakemake_rules/prepare.smk
+++ b/phylogenetic/workflow/snakemake_rules/prepare.smk
@@ -6,8 +6,8 @@ rule download:
         sequences="data/sequences.fasta.xz",
         metadata="data/metadata.tsv.gz",
     params:
-        sequences_url="https://data.nextstrain.org/files/workflows/monkeypox/sequences.fasta.xz",
-        metadata_url="https://data.nextstrain.org/files/workflows/monkeypox/metadata.tsv.gz",
+        sequences_url="https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz",
+        metadata_url="https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz",
     shell:
         """
         curl -fsSL --compressed {params.sequences_url:q} --output {output.sequences}


### PR DESCRIPTION
This commit goes through the repo and basically does a find-and-replace of "monkeypox" to "mpox, except for a handful of locations like the #monkeypox-updates Slack notification. 

This shouldn't change appearance of build outputs except for:
- Updating to "Built by nextstrain/mpox"
- Updating page titles to be more descriptive of what each page is showing in terms of lineages / clades
- A bug fix to the page description to link to proper build URLs (currently these go to 404)

This has the side effect that intermediate files will begin to propagate to https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz, etc... rather than `/files/workflows/monkeypox`. This may affect users who've been relying on the current URLs. Nothing should break for these users as the old files will continue to exist but they will no longer receive updated data. I think this is an okay trade-off in terms of downstream impacts.
