### PR TITLE
.github/workflows: Use centralized SLACK_CHANNELS variable

### DIFF
--- a/.github/workflows/fetch-and-ingest.yaml
+++ b/.github/workflows/fetch-and-ingest.yaml
@@ -42,7 +42,7 @@ jobs:
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         GITHUB_RUN_ID: ${{ github.run_id }}
-        SLACK_CHANNELS: monkeypox-updates
+        SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
       run: |
         nextstrain build \
           --detach \

--- a/.github/workflows/rebuild-hmpxv1-big.yaml
+++ b/.github/workflows/rebuild-hmpxv1-big.yaml
@@ -30,7 +30,7 @@ jobs:
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         GITHUB_RUN_ID: ${{ github.run_id }}
-        SLACK_CHANNELS: monkeypox-updates
+        SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
         BUILD_NAME: hmpxv1_big
       run: |

--- a/.github/workflows/rebuild-hmpxv1.yaml
+++ b/.github/workflows/rebuild-hmpxv1.yaml
@@ -30,7 +30,7 @@ jobs:
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         GITHUB_RUN_ID: ${{ github.run_id }}
-        SLACK_CHANNELS: monkeypox-updates
+        SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
         BUILD_NAME: hmpxv1
       run: |

--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -30,7 +30,7 @@ jobs:
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         GITHUB_RUN_ID: ${{ github.run_id }}
-        SLACK_CHANNELS: monkeypox-updates
+        SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
         BUILD_NAME: mpxv
       run: |


### PR DESCRIPTION
## Description of proposed changes

Using the centralized variable makes it easier for us to update the slack channel value when needed.

As a part of this change, I've already added the SLACK_CHANNELS variable to the repo. I opted to use the channel ID instead of the channel name so that we have the option to rename the slack channel if desired.

## Related issue(s)

Related to https://github.com/nextstrain/mpox/pull/220

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
