### PR TITLE
Fix ingest uploads

### DIFF
--- a/ingest/workflow/snakemake_rules/upload.smk
+++ b/ingest/workflow/snakemake_rules/upload.smk
@@ -35,9 +35,9 @@ def _get_upload_inputs(wildcards):
     if send_notifications:
         flag_file = []
 
-        if file_to_upload == "data/genbank.ndjson":
+        if inputs["file_to_upload"] == "data/genbank.ndjson":
             flag_file = "data/notify/genbank-record-change.done"
-        elif file_to_upload == "results/metadata.tsv":
+        elif inputs["file_to_upload"] == "results/metadata.tsv":
             flag_file = "data/notify/metadata-diff.done"
 
         inputs["notify_flag_file"] = flag_file


### PR DESCRIPTION
Fix bug that was introduced in https://github.com/nextstrain/mpox/pull/222

The testing done on branch runs do not include the Slack notifications, so this bug was not revealed in the test run. I only noticed the workflow as failing because our internal #monkeypox-updates channel had been quiet for over a week.

This did not trigger our usual error notifications in Slack because the error occurs during the DAG building process before the start of the actual workflow run.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Test run in https://github.com/nextstrain/mpox/actions/runs/6882965932

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
