### PR TITLE
fetch-and-ingest-branch: Send Slack notications to test channel

### DIFF
--- a/.github/workflows/fetch-and-ingest-branch.yaml
+++ b/.github/workflows/fetch-and-ingest-branch.yaml
@@ -34,6 +34,8 @@ jobs:
       runtime: aws-batch
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        GITHUB_RUN_ID: ${{ github.run_id }}
+        SLACK_CHANNELS: ${{ vars.TEST_SLACK_CHANNEL }}
         UPLOAD_CONFIG: ${{ needs.set_config_overrides.outputs.upload_config }}
       run: |
         nextstrain build \
@@ -44,6 +46,9 @@ jobs:
           --memory 64gib \
           --env AWS_ACCESS_KEY_ID \
           --env AWS_SECRET_ACCESS_KEY \
+          --env GITHUB_RUN_ID \
+          --env SLACK_TOKEN \
+          --env SLACK_CHANNELS \
           ingest \
             --configfiles config/config.yaml config/optional.yaml \
-            --config trigger_rebuild=False send_slack_notifications=False upload="$UPLOAD_CONFIG"
+            --config trigger_rebuild=False send_slack_notifications=True upload="$UPLOAD_CONFIG"


### PR DESCRIPTION
This change was motivated by the unintentional bug introduced in https://github.com/nextstrain/mpox/pull/222 that would only be triggered by using Slack notifications. This allows to test branches and send notifications to the testing channel.

As part of this change, I've added an organization level variable `TEST_SLACK_CHANNEL` that points our #scratch channel for testing Slack notifications.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Test run: https://github.com/nextstrain/mpox/actions/runs/6883650646 -> successful [Slack notifications in #scratch ](https://bedfordlab.slack.com/archives/C02LTGS6NLQ/p1700087415564329)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
