### PR TITLE
Version nextclade binary for transition, i.e. nextclade -> nextclade2

### DIFF
--- a/ingest/workflow/snakemake_rules/nextclade.smk
+++ b/ingest/workflow/snakemake_rules/nextclade.smk
@@ -32,7 +32,7 @@ rule align:
     threads: 4
     shell:
         """
-        nextclade run -D {input.dataset} -j {threads}   --retry-reverse-complement \
+        nextclade2 run -D {input.dataset} -j {threads}   --retry-reverse-complement \
                   --output-fasta {output.alignment}  --output-translations {params.translations} \
                   --output-insertions {output.insertions} {input.sequences}
         zip -rj {output.translations} data/translations
@@ -48,7 +48,7 @@ rule nextclade:
     threads: 4
     shell:
         """
-        nextclade run -D {input.dataset} -j {threads} --output-tsv {output}  {input.sequences}  --retry-reverse-complement
+        nextclade2 run -D {input.dataset} -j {threads} --output-tsv {output}  {input.sequences}  --retry-reverse-complement
         """
 
 


### PR DESCRIPTION
Soon we will release nextclade v3. Once nextclade v3 hits bioconda, workflows that rely on v2 syntax will break. To prevent this, this PR makes it explicit that the syntax used is for v2 and that the v2 binary nextclade2 should be used.

This binary is in both the nextstrain-base docker image and in the conda-base managed conda environment.

Users who don't use either will have to add nextclade2 to the path.

Over the next few weeks, we will transition repos to use nextclade3. The reason to add nextclade2 now is so that workflows don't break if they haven't yet transitioned to nextclade3 at the time of v3 release. It also makes it easy to search which workflows need to be changed.
