### PR TITLE
ingest: download Nextclade V2 dataset

### DIFF
--- a/ingest/workflow/snakemake_rules/nextclade.smk
+++ b/ingest/workflow/snakemake_rules/nextclade.smk
@@ -4,7 +4,7 @@ rule nextclade_dataset:
         temp("mpxv.zip"),
     shell:
         """
-        nextclade dataset get --name MPXV --output-zip {output}
+        nextclade2 dataset get --name MPXV --output-zip {output}
         """
 
 
@@ -13,7 +13,7 @@ rule nextclade_dataset_hMPXV:
         temp("hmpxv.zip"),
     shell:
         """
-        nextclade dataset get --name hMPXV --output-zip {output}
+        nextclade2 dataset get --name hMPXV --output-zip {output}
         """
 
 


### PR DESCRIPTION
## Description of proposed changes
The automated ingest pipeline failed during align with `nextclade2` with an error "specified file not found in archive".¹

I believe this is due to the `nextclade dataset` command downloading a Nextclade V3 dataset. I verified locally that using `nextclade2 dataset` will download a V2 dataset.

¹ https://bedfordlab.slack.com/archives/C03J4JG4ZE0/p1705594390033449

## Related issue(s)

Follow up on https://github.com/nextstrain/mpox/pull/226

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
