### PR TITLE
Use mutations rather than mutations-per-site for clade IIb/B.1 builds

### DIFF
--- a/phylogenetic/config/hmpxv1/config.yaml
+++ b/phylogenetic/config/hmpxv1/config.yaml
@@ -70,6 +70,7 @@ timetree: true
 root: "MK783032 MK783030"
 clock_rate: 5.7e-5
 clock_std_dev: 2e-5
+divergence_units: "mutations"
 
 ## recency
 recency: true

--- a/phylogenetic/config/hmpxv1_big/config.yaml
+++ b/phylogenetic/config/hmpxv1_big/config.yaml
@@ -49,6 +49,7 @@ timetree: true
 root: "OP890401"
 clock_rate: 5.7e-5
 clock_std_dev: 2e-5
+divergence_units: "mutations"
 
 ## recency
 recency: true

--- a/phylogenetic/config/mpxv/config.yaml
+++ b/phylogenetic/config/mpxv/config.yaml
@@ -66,6 +66,7 @@ timetree: false
 root: "min_dev"
 clock_rate: 3e-6
 clock_std_dev: 6e-6
+divergence_units: "mutations-per-site"
 
 ## recency
 recency: true

--- a/phylogenetic/profiles/ci/builds.yaml
+++ b/phylogenetic/profiles/ci/builds.yaml
@@ -73,6 +73,7 @@ timetree: true
 root: "MK783032 MK783030"
 clock_rate: 5.7e-5
 clock_std_dev: 2e-5
+divergence_units: "mutations"
 
 ## recency
 recency: true

--- a/phylogenetic/workflow/snakemake_rules/core.smk
+++ b/phylogenetic/workflow/snakemake_rules/core.smk
@@ -221,7 +221,6 @@ rule refine:
         - use {params.coalescent} coalescent timescale
         - estimate {params.date_inference} node dates
         - filter tips more than {params.clock_filter_iqd} IQDs from clock expectation
-    Note: --use-fft was removed (temporarily) due to https://github.com/neherlab/treetime/issues/242
     """
     input:
         tree=rules.fix_tree.output.tree
@@ -244,6 +243,7 @@ rule refine:
         if "clock_std_dev" in config
         else "",
         strain_id=config["strain_id_field"],
+        divergence_units=config["divergence_units"],
     shell:
         """
         augur refine \
@@ -263,6 +263,7 @@ rule refine:
             --coalescent {params.coalescent} \
             --date-inference {params.date_inference} \
             --date-confidence \
+            --divergence-units {params.divergence_units} \
             --clock-filter-iqd {params.clock_filter_iqd}
         """
 


### PR DESCRIPTION
For clade IIb/B.1. divergence is on the order of 1/10000 per site or less 10-100 mutations

I find mutations easier to reason about and there are fewer 0s:

<img width="1082" alt="image" src="https://github.com/nextstrain/mpox/assets/25161793/be98847d-96f7-4f54-bf1d-a751df575f59">

<img width="1082" alt="image" src="https://github.com/nextstrain/mpox/assets/25161793/6bdfad4e-b0f6-4900-9c9b-a73f9d986205">

<img width="1118" alt="image" src="https://github.com/nextstrain/mpox/assets/25161793/fbab57be-14c6-42fe-a8ec-9955cd616a1b">
