### PR TITLE
Fix trial rebuilds

### DIFF
--- a/.github/workflows/rebuild-hmpxv1-big.yaml
+++ b/.github/workflows/rebuild-hmpxv1-big.yaml
@@ -47,7 +47,7 @@ jobs:
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
         GITHUB_RUN_ID: ${{ github.run_id }}
-        SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
+        SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
         BUILD_NAME: hmpxv1_big
       run: |

--- a/.github/workflows/rebuild-hmpxv1-big.yaml
+++ b/.github/workflows/rebuild-hmpxv1-big.yaml
@@ -9,18 +9,34 @@ on:
   workflow_dispatch:
     inputs:
       trial_name:
-        description: "If set, result will be at nextstrain.org/staging/trial/trial_name/mpox/mpxv"
+        description: "If set, result will be at nextstrain.org/staging/trial/${trial_name}/${auspice_name}"
         required: false
       image:
         description: 'Specific container image to use for build (will override the default of "nextstrain build")'
         required: false
 
-env:
-  TRIAL_NAME: ${{ github.event.inputs.trial_name }}
-  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
-
 jobs:
+  set_config_overrides:
+    runs-on: ubuntu-latest
+    steps:
+      - id: config
+        name: Set config overrides
+        env:
+          TRIAL_NAME: ${{ inputs.trial_name }}
+        run: |
+          config=""
+          if [[ "$TRIAL_NAME" ]]; then
+            config+="--config"
+            config+=" deploy_url='s3://nextstrain-staging/'"
+            config+=" auspice_prefix='"$TRIAL_NAME"'"
+          fi
+
+          echo "config=$config" >> "$GITHUB_OUTPUT"
+    outputs:
+      config_overrides: ${{ steps.config.outputs.config }}
+
   rebuild_hmpxv1_big:
+    needs: [set_config_overrides]
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
@@ -29,6 +45,7 @@ jobs:
       runtime: aws-batch
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
@@ -47,4 +64,4 @@ jobs:
           . \
             notify_on_deploy \
               --configfiles $BUILD_DIR/config/$BUILD_NAME/config.yaml $BUILD_DIR/config/nextstrain_automation.yaml \
-              --config auspice_prefix=$TRIAL_NAME --directory $BUILD_DIR --snakefile $BUILD_DIR/Snakefile
+              $CONFIG_OVERRIDES --directory $BUILD_DIR --snakefile $BUILD_DIR/Snakefile

--- a/.github/workflows/rebuild-hmpxv1.yaml
+++ b/.github/workflows/rebuild-hmpxv1.yaml
@@ -9,18 +9,34 @@ on:
   workflow_dispatch:
     inputs:
       trial_name:
-        description: "If set, result will be at nextstrain.org/staging/trial/trial_name/mpox/mpxv"
+        description: "If set, result will be at nextstrain.org/staging/trial/${trial_name}/${auspice_name}"
         required: false
       image:
         description: 'Specific container image to use for build (will override the default of "nextstrain build")'
         required: false
 
-env:
-  TRIAL_NAME: ${{ github.event.inputs.trial_name }}
-  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
-
 jobs:
+  set_config_overrides:
+    runs-on: ubuntu-latest
+    steps:
+      - id: config
+        name: Set config overrides
+        env:
+          TRIAL_NAME: ${{ inputs.trial_name }}
+        run: |
+          config=""
+          if [[ "$TRIAL_NAME" ]]; then
+            config+="--config"
+            config+=" deploy_url='s3://nextstrain-staging/'"
+            config+=" auspice_prefix='"$TRIAL_NAME"'"
+          fi
+
+          echo "config=$config" >> "$GITHUB_OUTPUT"
+    outputs:
+      config_overrides: ${{ steps.config.outputs.config }}
+
   rebuild_hmpxv1:
+    needs: [set_config_overrides]
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
@@ -29,6 +45,7 @@ jobs:
       runtime: aws-batch
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
@@ -47,4 +64,4 @@ jobs:
           . \
             notify_on_deploy \
             --configfiles $BUILD_DIR/config/$BUILD_NAME/config.yaml $BUILD_DIR/config/nextstrain_automation.yaml \
-            --config auspice_prefix=$TRIAL_NAME --directory $BUILD_DIR --snakefile $BUILD_DIR/Snakefile
+            $CONFIG_OVERRIDES --directory $BUILD_DIR --snakefile $BUILD_DIR/Snakefile

--- a/.github/workflows/rebuild-hmpxv1.yaml
+++ b/.github/workflows/rebuild-hmpxv1.yaml
@@ -47,7 +47,7 @@ jobs:
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
         GITHUB_RUN_ID: ${{ github.run_id }}
-        SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
+        SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
         BUILD_NAME: hmpxv1
       run: |

--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -47,7 +47,7 @@ jobs:
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
         GITHUB_RUN_ID: ${{ github.run_id }}
-        SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
+        SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
         BUILD_NAME: mpxv
       run: |

--- a/.github/workflows/rebuild-mpxv.yaml
+++ b/.github/workflows/rebuild-mpxv.yaml
@@ -9,18 +9,34 @@ on:
   workflow_dispatch:
     inputs:
       trial_name:
-        description: "If set, result will be at nextstrain.org/staging/trial/trial_name/mpox/mpxv"
+        description: "If set, result will be at nextstrain.org/staging/trial/${trial_name}/${auspice_name}"
         required: false
       image:
         description: 'Specific container image to use for build (will override the default of "nextstrain build")'
         required: false
 
-env:
-  TRIAL_NAME: ${{ github.event.inputs.trial_name }}
-  NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.image }}
-
 jobs:
+  set_config_overrides:
+    runs-on: ubuntu-latest
+    steps:
+      - id: config
+        name: Set config overrides
+        env:
+          TRIAL_NAME: ${{ inputs.trial_name }}
+        run: |
+          config=""
+          if [[ "$TRIAL_NAME" ]]; then
+            config+="--config"
+            config+=" deploy_url='s3://nextstrain-staging/'"
+            config+=" auspice_prefix='"$TRIAL_NAME"'"
+          fi
+
+          echo "config=$config" >> "$GITHUB_OUTPUT"
+    outputs:
+      config_overrides: ${{ steps.config.outputs.config }}
+
   rebuild_mpxv:
+    needs: [set_config_overrides]
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
@@ -29,6 +45,7 @@ jobs:
       runtime: aws-batch
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
         BUILD_DIR: phylogenetic
@@ -47,4 +64,4 @@ jobs:
           . \
             notify_on_deploy \
               --configfiles $BUILD_DIR/config/$BUILD_NAME/config.yaml $BUILD_DIR/config/nextstrain_automation.yaml \
-              --config auspice_prefix=$TRIAL_NAME --directory $BUILD_DIR --snakefile $BUILD_DIR/Snakefile
+              $CONFIG_OVERRIDES --directory $BUILD_DIR --snakefile $BUILD_DIR/Snakefile


### PR DESCRIPTION
## Description of proposed changes

Fix trial rebuilds for phylogenetic workflows by setting config overrides and sending trial build messages to the testing Slack channel (#scratch). 

## Related issue(s)

Follow up to 
- https://github.com/nextstrain/mpox/pull/190
- https://github.com/nextstrain/mpox/pull/199

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Test [mpxv trial bulid](https://github.com/nextstrain/mpox/actions/runs/7922009111) -> deployed to https://nextstrain.org/staging/trial/fix-trial-rebuilds/mpox/all-clades
- [x] Test [hmpxv1 trial build](https://github.com/nextstrain/mpox/actions/runs/7923075884) -> deployed to https://nextstrain.org/staging/trial/fix-trial-rebuilds/mpox/clade-IIb
- [x] Test [hmpxv1-big trial build](https://github.com/nextstrain/mpox/actions/runs/7923077943) -> deployed to https://nextstrain.org/staging/trial/fix-trial-rebuilds/mpox/lineage-B.1

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
