### PR TITLE
Tweak clade I definitions and exclude misaligned/overdiverged

### DIFF
--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -16,24 +16,28 @@ If you're unfamiliar with Nextstrain builds, you may want to follow our
 The easiest way to run this pathogen build is using the Nextstrain
 command-line tool from within the `phylogenetic/` directory:
 
-    cd phylogenetic/
-    nextstrain build .
+```bash
+cd phylogenetic/
+nextstrain build .
+```
 
 Once you've run the build, you can view the results with:
 
-    nextstrain view .
+```bash
+nextstrain view .
+```
 
 ### Example build
 
 You can run an example build using the example data provided in this repository via:
 
-```
+```bash
 nextstrain build .  --configfile build-configs/ci/config.yaml
 ```
 
 When the build has finished running, view the output Auspice trees via:
 
-```
+```bash
 nextstrain view .
 ```
 
@@ -53,7 +57,7 @@ If you analyze and plan to publish using these data, please contact these labs f
 Within the analysis pipeline, these data are fetched from data.nextstrain.org and written to `data/` with:
 
 ```bash
-nextstrain build . data/sequences.fasta data/metadata.tsv
+nextstrain build . data/sequences.fasta.xz data/metadata.tsv.gz
 ```
 
 ### Run analysis pipeline
@@ -107,7 +111,7 @@ It can also be used as a small subset of real-world data.
 Example data should be updated every time metadata schema is changed or a new clade/lineage emerges.
 To update, run:
 
-```sh
+```bash
 nextstrain build . update_example_data -F \
     --configfiles build-configs/ci/config.yaml build-configs/chores/config.yaml
 ```

--- a/phylogenetic/defaults/clades.tsv
+++ b/phylogenetic/defaults/clades.tsv
@@ -2,8 +2,8 @@
 clade	gene	site	alt
 outgroup	nuc	179226	T
 
-clade I	nuc	86502	T
-clade I	nuc	35352	A
+clade I	nuc	87560	T
+clade I	nuc	136015	A
 
 clade II	nuc	86502	G
 clade II	nuc	150970	A

--- a/phylogenetic/defaults/exclude_accessions.txt
+++ b/phylogenetic/defaults/exclude_accessions.txt
@@ -74,3 +74,8 @@ PP098595
 PP098578
 
 HM172544	# cidofovir-resistant lab strain that is derived from DQ011155 (h/t Andrew Rambaut)
+
+TMP0003	# Overdiverged 23MPX1786C
+TMP0045	# Overdiverged RDC-NKV-GOM-MPOX-004
+
+NC_003310	# Overdiverged RefSeq NC_003310


### PR DESCRIPTION
- **Exclude 3 overdiverged clade I sequences**
- **Update clade I to include South Kivu cluster**

## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
