### PR TITLE
Switch CI to `pathogen-repo-ci` action [#257]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,24 +8,5 @@ on:
   workflow_dispatch:
 
 jobs:
-  pathogen-ci:
-    strategy:
-      matrix:
-        runtime: [docker, conda]
-    permissions:
-      id-token: write
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
-    secrets: inherit
-    with:
-      runtime: ${{ matrix.runtime }}
-      run: |
-        nextstrain build \
-          phylogenetic \
-          --configfiles build-configs/ci/config.yaml
-      artifact-name: output-${{ matrix.runtime }}
-      artifact-paths: |
-        phylogenetic/auspice/
-        phylogenetic/results/
-        phylogenetic/benchmarks/
-        phylogenetic/logs/
-        phylogenetic/.snakemake/log/
+  ci:
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,5 +1,6 @@
 exclude:
   - ingest/
+  - nextstrain-pathogen.yaml
 formatter:
   type: basic
   line_ending: lf

--- a/nextstrain-pathogen.yaml
+++ b/nextstrain-pathogen.yaml
@@ -1,0 +1,5 @@
+# This is currently an empty file to indicate the top level pathogen repo.
+# The inclusion of this file allows the Nextstrain CLI to run the
+# `nextstrain build` from any directory regardless of runtime.
+#
+# See https://github.com/nextstrain/cli/releases/tag/8.2.0 for more details.


### PR DESCRIPTION
## Description of proposed changes

Switch CI GitHub Action to use `pathogen-repo-ci` 

## Related issue(s)

* #257 
* https://github.com/nextstrain/.github/issues/94

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
