### PR TITLE
Sync .gitattributes with pathogen-repo-guide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+# Allow Git to decide if file is text or binary
 # Always use LF line endings even on Windows.
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
## Description of proposed changes

This change lets git detect text files. While potentially imperfect, it's better than assuming all files are text.

<https://github.com/nextstrain/pathogen-repo-guide/blob/e3bfb52c8155058a3d48592f4268a7382bf3e12a/.gitattributes>

## Related issue(s)

- https://github.com/nextstrain/pathogen-repo-guide/issues/46

## Checklist

- [x] Checks pass
