### PR TITLE
Check for mutations and clades before removing

### DIFF
--- a/phylogenetic/scripts/fix_tree.py
+++ b/phylogenetic/scripts/fix_tree.py
@@ -57,10 +57,14 @@ if __name__=="__main__":
                             print(f"Below {clade}: {mut_child} in {child.name} reverted in {grandchild.name}")
 
     for reversion in reversions:
-        # Remove reversion from grandchild
-        reversion["grandchild"].relevant_mutations.remove(reversion["mut_grandchild"])
-        # Remove grandchild from child
-        reversion["child"].clades.remove(reversion["grandchild"])
+        if reversion["mut_grandchild"] in reversion["grandchild"].relevant_mutations:
+            # Remove reversion from grandchild
+            reversion["grandchild"].relevant_mutations.remove(reversion["mut_grandchild"])
+
+        if reversion["grandchild"] in reversion["child"].clades:
+            # Remove grandchild from child
+            reversion["child"].clades.remove(reversion["grandchild"])
+
         # If there are mutations, add grandchild as child of parent
         if reversion["grandchild"].relevant_mutations != reversion["parent"].relevant_mutations:
             reversion["parent"].clades.append(reversion["grandchild"])


### PR DESCRIPTION
## Description of proposed changes

Fixes a bug in the fix_tree script when trying to remove mutations or clades from lists where those values don't exist. The short-term fix is to check for the presence of the values in the lists before trying to remove them. The long term fix is to use a different tree builder than eliminates the need for a "fix tree" script.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
