### PR TITLE
Update clade definition and coloring

### DIFF
--- a/phylogenetic/defaults/clades.tsv
+++ b/phylogenetic/defaults/clades.tsv
@@ -11,9 +11,9 @@ clade Ia	nuc	35352	A
 clade Ib	clade	clade I
 clade Ib	nuc	19455	T
 
+clade II	nuc	20605	A
 clade II	nuc	86502	G
-clade II	nuc	150970	A
-clade II	nuc	35352	C
+clade II	nuc	174146	C
 
 clade IIa	clade	clade II
 clade IIa	nuc	54013	G

--- a/phylogenetic/defaults/color_ordering.tsv
+++ b/phylogenetic/defaults/color_ordering.tsv
@@ -16884,7 +16884,8 @@ recency	New
 
 ################
 
-
+clade_membership	Ia
+clade_membership	Ib
 clade_membership	I
 clade_membership	II
 clade_membership	IIa


### PR DESCRIPTION
This PR:

1. Very slightly changes clade definition for "clade II". This results in no change to the resulting clade assignments.

Previously clade II definitions included nucleotide positions 35253 and 150970. However, neither of these positions show variation:
- [nextstrain.org/mpox/all-clades?c=gt-nuc_35253](https://nextstrain.org/mpox/all-clades?c=gt-nuc_35253)
- [nextstrain.org/mpox/all-clades?c=gt-nuc_150970](https://nextstrain.org/mpox/all-clades?c=gt-nuc_150970)

I updated these sites to 20605 and 174146 which show variation between clades I and II.

2. The color ordering lacked entries for clade Ia and clade Ib. This resulted in gray colors for these two clades at nextstrain.org/mpox/all-clades.

The resulting `all-clades` build looks like:

<img width="658" alt="Screenshot 2024-08-23 at 2 20 28 PM" src="https://github.com/user-attachments/assets/c81d2a41-5f45-41bd-b9c0-e380598aa1d8">

I don't think this should be too controversial, but could either @jameshadfield or @corneliusroemer take a very quick look?