### PR TITLE
phylogenetic: Add config option `ancestral_root_seq`

### DIFF
--- a/phylogenetic/build-configs/ci/config.yaml
+++ b/phylogenetic/build-configs/ci/config.yaml
@@ -2,6 +2,7 @@ custom_rules:
   - build-configs/ci/copy_example_data.smk
 
 reference: "defaults/reference.fasta"
+ancestral_root_seq: "defaults/reference.fasta"
 genome_annotation: "defaults/genome_annotation.gff3"
 genbank_reference: "defaults/reference.gb"
 include: "defaults/hmpxv1/include.txt"

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -31,13 +31,19 @@ rule ancestral:
         node_data=build_dir + "/{build_name}/nt_muts.json",
     params:
         inference="joint",
+        root_sequence=lambda w: (
+            f"--root-sequence {config['ancestral_root_seq']!r}"
+            if config.get("ancestral_root_seq")
+            else ""
+        ),
     shell:
         """
         augur ancestral \
             --tree {input.tree} \
             --alignment {input.alignment} \
             --output-node-data {output.node_data} \
-            --inference {params.inference}
+            --inference {params.inference} \
+            {params.root_sequence}
         """
 
 


### PR DESCRIPTION
## Description of proposed changes

Allow users to define an optional `--root-sequence` for `augur ancestral`.

This commit only adds the new config option to the CI config. It is not used in the default Nextstrain builds because it's not clear whether it's needed.

## Related issue(s)

https://github.com/nextstrain/mpox/issues/296

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
