### PR TITLE
phylogenetic: Add author coloring & filter for all builds

### DIFF
--- a/phylogenetic/defaults/clade-i/auspice_config.json
+++ b/phylogenetic/defaults/clade-i/auspice_config.json
@@ -92,8 +92,8 @@
       "type": "categorical"
     },
     {
-      "key": "abbr_authors",
-      "title": "Abbreviated Authors",
+      "key": "author",
+      "title": "Authors",
       "type": "categorical"
     },
     {
@@ -118,6 +118,7 @@
     "country",
     "region",
     "recency",
-    "host"
+    "host",
+    "author"
   ]
 }

--- a/phylogenetic/defaults/hmpxv1/auspice_config.json
+++ b/phylogenetic/defaults/hmpxv1/auspice_config.json
@@ -55,6 +55,11 @@
       "key": "date",
       "title": "Collection date",
       "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -72,6 +77,7 @@
     "country",
     "region",
     "recency",
-    "host"
+    "host",
+    "author"
   ]
 }

--- a/phylogenetic/defaults/hmpxv1_big/auspice_config.json
+++ b/phylogenetic/defaults/hmpxv1_big/auspice_config.json
@@ -60,6 +60,11 @@
       "key": "date",
       "title": "Collection date",
       "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -77,6 +82,7 @@
     "country",
     "region",
     "recency",
-    "host"
+    "host",
+    "author"
   ]
 }

--- a/phylogenetic/defaults/mpxv/auspice_config.json
+++ b/phylogenetic/defaults/mpxv/auspice_config.json
@@ -65,6 +65,11 @@
       "key": "date",
       "title": "Collection date",
       "type": "categorical"
+    },
+    {
+      "key": "author",
+      "title": "Authors",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -82,6 +87,7 @@
     "country",
     "region",
     "recency",
-    "host"
+    "host",
+    "author"
   ]
 }


### PR DESCRIPTION
## Description of proposed changes

Since <https://github.com/nextstrain/mpox/pull/295>, the metadata includes the abbreviated authors list in the "authors" column of the metadata.tsv. However, `augur export` renames `authors` -> `author`,¹ so we must use `author` in the auspice_config.json to include it as coloring and filters.

Resolves <https://github.com/nextstrain/mpox/issues/311>

¹ <https://github.com/nextstrain/augur/blob/be4215b17c03796bd8c75fb5fc3d6b5bb4c83438/augur/export_v2.py#L172>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
