### PR TITLE
ingest: Add zstd compressed outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Instead, changes appear below grouped by the date they were added to the workflo
 
 ## 2025
 
+* 23 June 2025: added the following zstd compressed outputs. ([#317][])
+    * https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.zst
+    * https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.zst
+    * https://data.nextstrain.org/files/workflows/mpox/alignment.fasta.zst
 * 23 June 2025: ingest - updated intermediate NDJSON file. ([#316][])
     * Removed the following intermediate NDJSON files
         * https://data.nextstrain.org/files/workflows/mpox/all_sequences.ndjson.xz
@@ -19,5 +23,6 @@ Instead, changes appear below grouped by the date they were added to the workflo
 * 23 June 2025: ingest - removed path for separate data sources. ([#316][])
     * The config param `sources` is no longer supported
 
+[#317]: https://github.com/nextstrain/mpox/pull/317
 [#316]: https://github.com/nextstrain/mpox/pull/316
 [NCBI Datasets mnemonics]: https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/command-line/dataformat/tsv/dataformat_tsv_virus-genome/#fields

--- a/ingest/build-configs/nextstrain-automation/config.yaml
+++ b/ingest/build-configs/nextstrain-automation/config.yaml
@@ -13,12 +13,17 @@ upload:
     dst: 's3://nextstrain-data/files/workflows/mpox'
     # Mapping of files to upload, with key as remote file name and the value
     # the local file path relative to the ingest directory.
+    # .gz/.xz targets will be removed by 28 July 2025
+    # to avoid duplicate files with different compressions
     files_to_upload:
       ncbi.ndjson.zst: data/ncbi.ndjson
       metadata.tsv.gz: results/metadata.tsv
+      metadata.tsv.zst: results/metadata.tsv
       sequences.fasta.xz: results/sequences.fasta
+      sequences.fasta.zst: results/sequences.fasta
       nextclade.tsv.zst: results/nextclade.tsv
       alignment.fasta.xz: results/alignment.fasta
+      alignment.fasta.zst: results/alignment.fasta
       translations.zip: results/translations.zip
 
     cloudfront_domain: 'data.nextstrain.org'


### PR DESCRIPTION
## Description of proposed changes

Add zstd compressed outputs to S3. Changes to use the zst files in our workflows in https://github.com/nextstrain/mpox/pull/318. I plan to merge this PR first so that the zst files exist on S3 before merging the changes to use the zst files. 

In ~1 month, I'll remove the gz/xz file uploads and delete them from S3 so that we don't continue to upload duplicate files with different compressions. 

## Related issue(s)

Resolves <https://github.com/nextstrain/mpox/issues/137>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update CHANGELOG

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
