### PR TITLE
Use zstd compressed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Instead, changes appear below grouped by the date they were added to the workflo
 
 ## 2025
 
+* 25 June 2025: All workflows now use the zstd compressed outputs on S3. ([#318][])
+    Note that the gzip and xz compressed files on S3 will be removed by 28 July 2025,
+    so please update your workflows to use the zstd compressed files.
 * 23 June 2025: added the following zstd compressed outputs. ([#317][])
     * https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.zst
     * https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.zst
@@ -23,6 +26,7 @@ Instead, changes appear below grouped by the date they were added to the workflo
 * 23 June 2025: ingest - removed path for separate data sources. ([#316][])
     * The config param `sources` is no longer supported
 
+[#318]: https://github.com/nextstrain/mpox/pull/318
 [#317]: https://github.com/nextstrain/mpox/pull/317
 [#316]: https://github.com/nextstrain/mpox/pull/316
 [NCBI Datasets mnemonics]: https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/command-line/dataformat/tsv/dataformat_tsv_virus-genome/#fields

--- a/ingest/build-configs/nextstrain-automation/slack_notifications.smk
+++ b/ingest/build-configs/nextstrain-automation/slack_notifications.smk
@@ -44,7 +44,7 @@ rule notify_on_metadata_diff:
         s3_src=S3_SRC,
     shell:
         """
-        ./vendored/notify-on-diff {input.metadata} {params.s3_src:q}/metadata.tsv.gz
+        ./vendored/notify-on-diff {input.metadata} {params.s3_src:q}/metadata.tsv.zst
         """
 
 

--- a/ingest/build-configs/nextstrain-automation/trigger_rebuild.smk
+++ b/ingest/build-configs/nextstrain-automation/trigger_rebuild.smk
@@ -12,8 +12,8 @@ rule trigger_build:
     Triggering monekypox builds via repository action type `rebuild`.
     """
     input:
-        metadata_upload="data/upload/s3/metadata.tsv.gz.done",
-        fasta_upload="data/upload/s3/sequences.fasta.xz.done",
+        metadata_upload="data/upload/s3/metadata.tsv.zst.done",
+        fasta_upload="data/upload/s3/sequences.fasta.zst.done",
     output:
         touch("data/trigger/rebuild.done"),
     shell:

--- a/nextclade/Snakefile
+++ b/nextclade/Snakefile
@@ -58,11 +58,11 @@ rule deploy_to_nextstrain_staging:
 rule download:
     "Downloading ingested sequences and metadata from data.nextstrain.org"
     output:
-        sequences="data/sequences.fasta.xz",
-        metadata="data/metadata.tsv.gz",
+        sequences="data/sequences.fasta.zst",
+        metadata="data/metadata.tsv.zst",
     params:
-        sequences_url="https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz",
-        metadata_url="https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz",
+        sequences_url="https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.zst",
+        metadata_url="https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.zst",
     shell:
         """
         curl -fsSL --compressed {params.sequences_url:q} --output {output.sequences}
@@ -73,15 +73,15 @@ rule download:
 rule decompress:
     "Decompressing sequences and metadata"
     input:
-        sequences="data/sequences.fasta.xz",
-        metadata="data/metadata.tsv.gz",
+        sequences="data/sequences.fasta.zst",
+        metadata="data/metadata.tsv.zst",
     output:
         sequences="data/sequences.fasta",
         metadata="data/metadata.tsv",
     shell:
         """
-        gzip --decompress --keep {input.metadata}
-        xz --decompress --keep {input.sequences}
+        zstd --decompress --stdout {input.sequences:q} > {output.sequences:q}
+        zstd --decompress --stdout {input.metadata:q} > {output.metadata:q}
         """
 
 

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -45,8 +45,8 @@ nextstrain view .
 
 Input sequences and metadata can be retrieved from data.nextstrain.org
 
-* [sequences.fasta.xz](https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz)
-* [metadata.tsv.gz](https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz)
+* [sequences.fasta.zst](https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.zst)
+* [metadata.tsv.zst](https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.zst)
 
 The above datasets have been preprocessed and cleaned from GenBank using the
 [ingest/](../ingest/) workflow and are updated at regular intervals.
@@ -57,7 +57,7 @@ If you analyze and plan to publish using these data, please contact these labs f
 Within the analysis pipeline, these data are fetched from data.nextstrain.org and written to `data/` with:
 
 ```bash
-nextstrain build . data/sequences.fasta.xz data/metadata.tsv.gz
+nextstrain build . data/sequences.fasta.zst data/metadata.tsv.zst
 ```
 
 ### Run analysis pipeline

--- a/phylogenetic/defaults/description.md
+++ b/phylogenetic/defaults/description.md
@@ -23,11 +23,11 @@ We curate sequence data and metadata from the [NCBI Datasets command line tools]
 using an NCBI Taxonomy ID defined in [ingest/defaults/config.yaml](https://github.com/nextstrain/mpox/blob/-/ingest/defaults/config.yaml), as starting point for these analyses.
 
 Curated sequences and metadata are available as flat files at:
-- [data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz](https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz)
-- [data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz](https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz)
+- [data.nextstrain.org/files/workflows/mpox/sequences.fasta.zst](https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.zst)
+- [data.nextstrain.org/files/workflows/mpox/metadata.tsv.zst](https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.zst)
 
 Pairwise alignments with [Nextclade](https://clades.nextstrain.org/) against the [reference sequence MPXV-M5312_HM12_Rivers](https://www.ncbi.nlm.nih.gov/nuccore/NC_063383), Nextclade analysis results, and translated ORFs are available at
-- [data.nextstrain.org/files/workflows/mpox/alignment.fasta.xz](https://data.nextstrain.org/files/workflows/mpox/alignment.fasta.xz)
+- [data.nextstrain.org/files/workflows/mpox/alignment.fasta.zst](https://data.nextstrain.org/files/workflows/mpox/alignment.fasta.zst)
 - [data.nextstrain.org/files/workflows/mpox/nextclade.tsv.zst](https://data.nextstrain.org/files/workflows/mpox/nextclade.tsv.zst)
 - [data.nextstrain.org/files/workflows/mpox/translations.zip](https://data.nextstrain.org/files/workflows/mpox/translations.zip)
 

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -20,11 +20,11 @@ rule download:
     Downloading sequences and metadata from data.nextstrain.org
     """
     output:
-        sequences="data/sequences.fasta.xz",
-        metadata="data/metadata.tsv.gz",
+        sequences="data/sequences.fasta.zst",
+        metadata="data/metadata.tsv.zst",
     params:
-        sequences_url="https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.xz",
-        metadata_url="https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.gz",
+        sequences_url="https://data.nextstrain.org/files/workflows/mpox/sequences.fasta.zst",
+        metadata_url="https://data.nextstrain.org/files/workflows/mpox/metadata.tsv.zst",
     shell:
         """
         curl -fsSL --compressed {params.sequences_url:q} --output {output.sequences}
@@ -37,15 +37,15 @@ rule decompress:
     Decompressing sequences and metadata
     """
     input:
-        sequences="data/sequences.fasta.xz",
-        metadata="data/metadata.tsv.gz",
+        sequences="data/sequences.fasta.zst",
+        metadata="data/metadata.tsv.zst",
     output:
         sequences="data/sequences.fasta",
         metadata="data/metadata.tsv",
     shell:
         """
-        gzip --decompress --keep {input.metadata}
-        xz --decompress --keep {input.sequences}
+        zstd --decompress --stdout {input.sequences:q} > {output.sequences:q}
+        zstd --decompress --stdout {input.metadata:q} > {output.metadata:q}
         """
 
 


### PR DESCRIPTION
## Description of proposed changes

Switch all workflows to using the zstd compressed files on S3.

I plan to merge this after https://github.com/nextstrain/mpox/pull/317 has been merged and the ingest workflow has run at least once so that the zst files exist on S3. 

## Related issue(s)

Related to https://github.com/nextstrain/mpox/issues/137

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update CHANGELOG

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
